### PR TITLE
Filter slack webhookUrl to log

### DIFF
--- a/internal/destslack/destslack.go
+++ b/internal/destslack/destslack.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/psanford/cloudtrail-tattletail/config"
 	"github.com/psanford/cloudtrail-tattletail/internal/destination"
@@ -100,4 +101,13 @@ func (d *DestSlackWebhook) Send(name, desc string, rec map[string]interface{}, m
 	}
 
 	return slack.PostWebhook(d.webhookURL, &msg)
+}
+
+func (d *DestSlackWebhook) String() string {
+	paths := strings.Split(d.webhookURL, "/")
+	if len(paths) > 4 {
+		paths[len(paths)-1] = "**FILTERED**"
+	}
+
+	return fmt.Sprintf("{id: %s webhookURL: %s}", d.id, strings.Join(paths, "/"))
 }

--- a/internal/destslack/destslack_test.go
+++ b/internal/destslack/destslack_test.go
@@ -1,0 +1,29 @@
+package destslack
+
+import "testing"
+
+func TestString(t *testing.T) {
+	d := DestSlackWebhook{
+		id:         "slack webhook",
+		webhookURL: "https://hooks.slack.com/services/T00000000/B00000000/XXXX_SENSITIVE_URL_XXXX",
+	}
+
+	actual := d.String()
+	expected := "{id: slack webhook webhookURL: https://hooks.slack.com/services/T00000000/B00000000/**FILTERED**}"
+	if actual != expected {
+		t.Errorf("expecting %s, got %s", expected, actual)
+	}
+}
+
+func TestStringSimpleURL(t *testing.T) {
+	d := DestSlackWebhook{
+		id:         "slack webhook",
+		webhookURL: "https://hooks.slack.com/services",
+	}
+
+	actual := d.String()
+	expected := "{id: slack webhook webhookURL: https://hooks.slack.com/services}"
+	if actual != expected {
+		t.Errorf("expecting %s, got %s", expected, actual)
+	}
+}


### PR DESCRIPTION
Thank you for the great product 👍 
This is what I wanted. 😄 

As a feature I need.
I want to filter and output the WebHook URL in the Lambda execution log.

![image](https://user-images.githubusercontent.com/2988939/141754592-4f0a2c07-99e2-4486-b2de-cfc20d0195b7.png)
